### PR TITLE
Refactor: LSP-based restructure, sex-encoding bug fix, tests/CI (v2.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project (with dev dependencies)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Ruff lint
+        run: python -m ruff check .
+
+      - name: Ruff format check
+        run: python -m ruff format --check .
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2026-06-15
+
+Full structural refactor applying the Liskov Substitution Principle and general
+script best-practices, while preserving the public API
+(`load_model`, `predict_dataframe`) and the deployed Streamlit application.
+
+### Fixed
+- **Individual / single-sex predictions were wrong.** Feature preparation refit a
+  `OneHotEncoder(drop="first")` on every call, so a batch containing a single sex
+  (including the single-row *Individual Patient* form) produced no `sex_M` column
+  and silently fell back to `sex_M = 0`, scoring **male patients as female**.
+  Encoding is now deterministic (`M -> 1`, otherwise `0`). For example, a male
+  patient with `age=40, diameter=2.5, adc=0.5` was previously reported as
+  *non-soft* (~95%); it is now correctly reported as *soft* (~29%). Mixed-sex
+  batch outputs are unchanged (verified by a non-regression test).
+
+### Added
+- `adenopredict.constants`: single source of truth for the schema, label maps and
+  decision threshold (removes constants duplicated across modules).
+- `adenopredict.preprocessing`: deterministic, unit-tested feature preparation
+  (`validate_input`, `encode_sex`, `map_target`, `prepare_features`).
+- `adenopredict.estimators`: a Liskov-compliant `ProbabilityEstimator` strategy
+  hierarchy (`ProbaEstimator`, `DecisionFunctionEstimator`, `LabelEstimator`) with
+  a `make_estimator` factory, replacing inline `hasattr` branching. Every subtype
+  honours the same contract — return positive-class probabilities in `[0, 1]` of
+  shape `(n,)` — so they are fully substitutable.
+- `app/service.py`: a Streamlit-agnostic prediction service (`run_prediction`,
+  `PredictionResult`) separating data/model logic from rendering.
+- Test suite (`tests/`, pytest) covering the sex-encoding fix, estimator
+  strategies, input validation and end-to-end inference, including a
+  non-regression check against the bundled SVM model.
+- Tooling: `ruff` (lint + format) and `pytest` configuration in `pyproject.toml`,
+  plus a GitHub Actions CI workflow (Python 3.11 / 3.12).
+
+### Changed
+- `adenopredict.inference.predict_dataframe` is now a thin orchestrator over the
+  preprocessing and estimator modules and accepts an optional `threshold`.
+- Streamlit page renderers (`app/pages.py`) were decomposed into small helpers,
+  with specific exception handling and no silent failures or redundant local
+  imports.
+- `examples/model_apply.py` is now a clean `argparse` CLI that reuses the library
+  instead of re-implementing preprocessing, and no longer auto-installs packages.
+- `app/config.py` and `app/data.py` reuse the shared constants and `pathlib`.
+
+## [2.0.0] - 2025-08-31
+
+- App modularization and organization improvements.
+
+## [1.0.0] - 2024-04-04
+
+- Initial release: SVM-based inference library and Streamlit application.
+
+[2.1.0]: https://github.com/davifmdhack/adeno_predict/compare/v.2.0.0...v.2.1.0
+[2.0.0]: https://github.com/davifmdhack/adeno_predict/releases/tag/v.2.0.0
+[1.0.0]: https://github.com/davifmdhack/adeno_predict/releases/tag/v.1.0.0

--- a/README.md
+++ b/README.md
@@ -148,6 +148,30 @@ streamlit run streamlit_app.py
 
 1. Upload your CSV with columns `age, sex, diameter, adc` (optional `consistency`). The app will generate probabilities and predictions. Results are saved to `results/df_prediction-results.csv`.
 
+## Project structure
+
+The inference library (`adenopredict/`) is organized around small, single-responsibility modules:
+
+- `constants.py` — single source of truth for the schema, label maps and decision threshold.
+- `preprocessing.py` — deterministic feature preparation (validation + `sex` encoding + target mapping).
+- `estimators.py` — substitutable `ProbabilityEstimator` strategies (`predict_proba` / `decision_function` / `predict`) following the Liskov Substitution Principle.
+- `inference.py` — public API (`load_model`, `predict_dataframe`) orchestrating the modules above.
+
+The Streamlit UI lives in `app/`, with a Streamlit-agnostic prediction service in `app/service.py`. A standalone reporting CLI is available at `examples/model_apply.py` (`python examples/model_apply.py --help`).
+
+## Development
+
+Install the project with development dependencies and run the quality gate (the same checks run in CI):
+
+```bash
+pip install -e ".[dev]"
+ruff check .
+ruff format --check .
+pytest -q
+```
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the history of notable changes.
+
 ---
 
 ### Article

--- a/adenopredict/__init__.py
+++ b/adenopredict/__init__.py
@@ -1,6 +1,17 @@
+"""AdenoPredict: inference library for pituitary macroadenoma consistency."""
+
+from .constants import LABEL_MAP, REQUIRED_COLUMNS, TARGET_COLUMN
+from .estimators import make_estimator
+from .inference import load_model, predict_dataframe
+from .preprocessing import map_target, prepare_features
+
 __all__ = [
     "load_model",
     "predict_dataframe",
+    "prepare_features",
+    "map_target",
+    "make_estimator",
+    "REQUIRED_COLUMNS",
+    "TARGET_COLUMN",
+    "LABEL_MAP",
 ]
-
-from .inference import load_model, predict_dataframe

--- a/adenopredict/constants.py
+++ b/adenopredict/constants.py
@@ -1,0 +1,30 @@
+"""Single source of truth for the AdenoPredict schema and label conventions.
+
+Centralizing these constants avoids the duplication that previously existed
+across ``inference.py``, ``app/config.py``, ``app/pages.py`` and the example
+script, where the same column lists and label maps were redefined by hand.
+"""
+
+from __future__ import annotations
+
+#: Raw input columns required from the user before any preprocessing.
+REQUIRED_COLUMNS: list[str] = ["age", "sex", "diameter", "adc"]
+
+#: Feature order expected by the trained scikit-learn pipeline.
+#: ``sex`` is encoded into ``sex_M`` (see :mod:`adenopredict.preprocessing`).
+FEATURE_ORDER: list[str] = ["age", "sex_M", "diameter", "adc"]
+
+#: Optional ground-truth column used to compute evaluation metrics.
+TARGET_COLUMN: str = "consistency"
+
+#: Mapping from human-readable consistency labels to integer classes.
+LABEL_MAP: dict[str, int] = {"soft": 0, "non-soft": 1}
+
+#: Inverse of :data:`LABEL_MAP`, used to render predictions back to text.
+INV_LABEL_MAP: dict[int, str] = {value: key for key, value in LABEL_MAP.items()}
+
+#: Value of the ``sex`` column that maps to ``sex_M = 1`` (positive encoding).
+MALE_LABEL: str = "M"
+
+#: Decision threshold applied to the positive-class probability.
+DEFAULT_THRESHOLD: float = 0.5

--- a/adenopredict/estimators.py
+++ b/adenopredict/estimators.py
@@ -1,0 +1,110 @@
+"""Substitutable probability estimators (Liskov-compliant strategy hierarchy).
+
+A fitted scikit-learn model may expose its confidence through different APIs:
+``predict_proba`` (calibrated probabilities), ``decision_function`` (unbounded
+margins) or only ``predict`` (hard labels). The previous code branched on
+``hasattr`` inline inside ``predict_dataframe``.
+
+Here that logic is expressed as a small hierarchy where every subclass honours
+the *same* contract, so any one can stand in for another without surprising the
+caller -- the Liskov Substitution Principle:
+
+* Precondition: ``X`` is the prepared feature matrix (same for all subtypes).
+* Postcondition: ``probabilities(X)`` returns a 1-D ``numpy`` array of length
+  ``len(X)`` with every value in ``[0, 1]``; no side effects, no
+  ``NotImplementedError``.
+
+:func:`make_estimator` selects the most informative available strategy, in the
+same priority order the original code used (proba > decision > label), so model
+outputs are unchanged for estimators that expose ``predict_proba``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import pandas as pd
+
+#: Index of the positive class (``non-soft``) in scikit-learn's class ordering.
+POSITIVE_CLASS_INDEX = 1
+
+
+class ProbabilityEstimator(ABC):
+    """Strategy that turns a fitted model into positive-class probabilities."""
+
+    def __init__(self, model: object) -> None:
+        self._model = model
+
+    @abstractmethod
+    def probabilities(self, X: pd.DataFrame) -> np.ndarray:
+        """Return ``P(positive class)`` in ``[0, 1]`` with shape ``(len(X),)``."""
+
+    @staticmethod
+    def supports(model: object) -> bool:
+        """Whether this strategy can be applied to ``model``."""
+        return False
+
+
+class ProbaEstimator(ProbabilityEstimator):
+    """Use a model's calibrated ``predict_proba`` output directly."""
+
+    @staticmethod
+    def supports(model: object) -> bool:
+        return hasattr(model, "predict_proba")
+
+    def probabilities(self, X: pd.DataFrame) -> np.ndarray:
+        proba = self._model.predict_proba(X)[:, POSITIVE_CLASS_INDEX]
+        return np.asarray(proba, dtype=float)
+
+
+class DecisionFunctionEstimator(ProbabilityEstimator):
+    """Min-max normalize ``decision_function`` margins into ``[0, 1]``."""
+
+    @staticmethod
+    def supports(model: object) -> bool:
+        return hasattr(model, "decision_function")
+
+    def probabilities(self, X: pd.DataFrame) -> np.ndarray:
+        scores = np.asarray(self._model.decision_function(X), dtype=float)
+        min_score, max_score = scores.min(), scores.max()
+        if max_score > min_score:
+            return (scores - min_score) / (max_score - min_score)
+        # Degenerate (constant) scores: fall back to sign of the margin.
+        return (scores > 0).astype(float)
+
+
+class LabelEstimator(ProbabilityEstimator):
+    """Last-resort strategy: treat hard ``predict`` labels as probabilities."""
+
+    @staticmethod
+    def supports(model: object) -> bool:
+        return hasattr(model, "predict")
+
+    def probabilities(self, X: pd.DataFrame) -> np.ndarray:
+        return np.asarray(self._model.predict(X), dtype=float)
+
+
+#: Strategies ordered from most to least informative.
+_STRATEGY_PRIORITY = (ProbaEstimator, DecisionFunctionEstimator, LabelEstimator)
+
+
+def make_estimator(model: object) -> ProbabilityEstimator:
+    """Return the most informative :class:`ProbabilityEstimator` for ``model``.
+
+    Args:
+        model: A fitted estimator or scikit-learn ``Pipeline``.
+
+    Returns:
+        A ready-to-use probability estimator wrapping ``model``.
+
+    Raises:
+        TypeError: If ``model`` exposes none of ``predict_proba``,
+            ``decision_function`` or ``predict``.
+    """
+    for strategy in _STRATEGY_PRIORITY:
+        if strategy.supports(model):
+            return strategy(model)
+    raise TypeError(
+        "Unsupported model: expected one of predict_proba, decision_function or predict."
+    )

--- a/adenopredict/inference.py
+++ b/adenopredict/inference.py
@@ -1,126 +1,59 @@
+"""Model loading and inference for AdenoPredict.
+
+This module keeps a small, stable public surface -- :func:`load_model` and
+:func:`predict_dataframe` -- while delegating the details to focused
+collaborators: :mod:`adenopredict.preprocessing` (feature preparation) and
+:mod:`adenopredict.estimators` (substitutable probability strategies).
+"""
+
 from __future__ import annotations
 
-from typing import List, Tuple
-
-import pandas as pd
 import joblib
-from sklearn.preprocessing import OneHotEncoder
+import pandas as pd
 
-
-REQUIRED_COLUMNS: List[str] = ["age", "sex", "diameter", "adc"]
-TARGET_COLUMN: str = "consistency"
-
-
-def _validate_input_dataframe(df: pd.DataFrame) -> None:
-    """Validate that the input DataFrame contains required columns.
-
-    Args:
-        df: Input features `DataFrame`.
-
-    Raises:
-        ValueError: If one or more required columns are missing.
-    """
-    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
-    if missing:
-        raise ValueError(
-            f"Missing columns: {missing}. Expected columns: {REQUIRED_COLUMNS}"
-        )
-
-
-def _prepare_features(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series | None]:
-    """Prepare features to match the training-time schema.
-
-    - Map optional target labels (soft/non-soft) to integers if present.
-    - One-hot encode `sex` with `drop='first'` to yield `sex_M`.
-    - Reorder/select feature columns in the expected order.
-
-    Args:
-        df: Raw input `DataFrame` with columns `age, sex, diameter, adc` and
-            optional `consistency`.
-
-    Returns:
-        A tuple `(X, y)` where `X` is the prepared feature `DataFrame` and `y` is
-        the optional target series (or `None` if not provided).
-    """
-    df_local = df.copy()
-
-    # Map target labels to integers if present
-    y = None
-    if TARGET_COLUMN in df_local.columns:
-        replace_map_outcome = {"soft": 0, "non-soft": 1}
-        df_local[TARGET_COLUMN] = df_local[TARGET_COLUMN].map(replace_map_outcome).fillna(df_local[TARGET_COLUMN])
-        y = df_local[TARGET_COLUMN]
-
-    # One-hot encode 'sex' (drop first) to produce 'sex_M'
-    encoder = OneHotEncoder(drop="first")
-    encoded = encoder.fit_transform(df_local[["sex"]]).toarray()
-    encoded_sex = pd.DataFrame(
-        encoded,
-        columns=encoder.get_feature_names_out(["sex"]),
-        index=df_local.index,
-    )
-
-    df_encoded = pd.concat([df_local.drop(["sex"], axis=1), encoded_sex], axis=1)
-
-    # Feature order expected by the trained model
-    x_columns = ["age", "sex_M", "diameter", "adc"]
-    for col in x_columns:
-        if col not in df_encoded.columns:
-            # Ensure column exists if encoder produced a different name
-            df_encoded[col] = 0
-
-    X = df_encoded[x_columns]
-    return X, y
+from .constants import DEFAULT_THRESHOLD, INV_LABEL_MAP
+from .estimators import make_estimator
+from .preprocessing import prepare_features
 
 
 def load_model(model_path: str):
-    """Load a serialized scikit-learn Pipeline/estimator.
+    """Load a serialized scikit-learn estimator or ``Pipeline``.
 
     Args:
-        model_path: Path to the `.pkl` file.
+        model_path: Path to the ``.pkl`` file.
 
     Returns:
-        The loaded estimator (ideally a scikit-learn Pipeline).
+        The loaded estimator (ideally a scikit-learn ``Pipeline``).
     """
     return joblib.load(model_path)
 
 
-def predict_dataframe(model, df: pd.DataFrame) -> pd.DataFrame:
-    """Predict non-soft consistency probability for each row in a DataFrame.
+def predict_dataframe(
+    model,
+    df: pd.DataFrame,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> pd.DataFrame:
+    """Predict non-soft consistency probability for each row of ``df``.
 
     Args:
-        model: A fitted estimator or scikit-learn Pipeline.
-        df: Input `DataFrame` with required columns.
+        model: A fitted estimator or scikit-learn ``Pipeline``.
+        df: Input ``DataFrame`` with the required feature columns.
+        threshold: Probability cut-off for the positive (``non-soft``) class.
 
     Returns:
-        DataFrame with columns:
-        - `proba_non_soft`: probability of the positive class.
-        - `predicted_label`: integer label (0 soft, 1 non-soft).
-        - `predicted_consistency`: human-readable label.
+        DataFrame indexed like ``df`` with columns:
+
+        * ``proba_non_soft``: probability of the positive class in ``[0, 1]``.
+        * ``predicted_label``: integer label (``0`` soft, ``1`` non-soft).
+        * ``predicted_consistency``: human-readable label.
     """
-    _validate_input_dataframe(df)
-    X, y = _prepare_features(df)
-
-    if hasattr(model, "predict_proba"):
-        proba = model.predict_proba(X)[:, 1]
-    else:
-        if hasattr(model, "decision_function"):
-            scores = model.decision_function(X)
-            min_s, max_s = scores.min(), scores.max()
-            proba = (scores - min_s) / (max_s - min_s) if max_s > min_s else (scores > 0).astype(float)
-        else:
-            preds = model.predict(X)
-            proba = preds.astype(float)
-
-    preds = (proba >= 0.5).astype(int)
+    X, _ = prepare_features(df)
+    proba = make_estimator(model).probabilities(X)
+    labels = (proba >= threshold).astype(int)
 
     result = pd.DataFrame(
-        {
-            "proba_non_soft": proba,
-            "predicted_label": preds,
-        },
+        {"proba_non_soft": proba, "predicted_label": labels},
         index=df.index,
     )
-
-    result["predicted_consistency"] = result["predicted_label"].map({0: "soft", 1: "non-soft"})
+    result["predicted_consistency"] = result["predicted_label"].map(INV_LABEL_MAP)
     return result

--- a/adenopredict/preprocessing.py
+++ b/adenopredict/preprocessing.py
@@ -1,0 +1,100 @@
+"""Deterministic feature preparation for AdenoPredict.
+
+This module is the single, testable place where raw input rows are validated
+and turned into the feature matrix expected by the trained model. It replaces
+the previous in-line preprocessing that refit a ``OneHotEncoder(drop="first")``
+on every call.
+
+Why the change matters
+----------------------
+``OneHotEncoder(drop="first")`` derives its output from the categories *present
+in the data it is fit on*. When a batch contained a single sex -- most notably
+the single-row "Individual Patient" prediction -- the encoder produced no
+``sex_M`` column and the code silently fell back to ``sex_M = 0``. A male
+patient was therefore scored as if female. Encoding ``sex`` deterministically
+(``M`` -> 1, anything else -> 0) removes that data dependence and fixes the bug
+while matching the training-time schema exactly for mixed-sex batches.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .constants import (
+    FEATURE_ORDER,
+    LABEL_MAP,
+    MALE_LABEL,
+    REQUIRED_COLUMNS,
+    TARGET_COLUMN,
+)
+
+
+def validate_input(df: pd.DataFrame) -> None:
+    """Ensure the input DataFrame contains every required column.
+
+    Args:
+        df: Raw input features.
+
+    Raises:
+        ValueError: If one or more of :data:`REQUIRED_COLUMNS` is missing.
+    """
+    missing = [column for column in REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns: {missing}. Expected columns: {REQUIRED_COLUMNS}")
+
+
+def encode_sex(sex: pd.Series) -> pd.Series:
+    """Encode the ``sex`` column as the binary ``sex_M`` feature.
+
+    The encoding is deterministic and row-independent: ``"M"`` maps to ``1`` and
+    every other value maps to ``0``. This mirrors the training-time
+    ``OneHotEncoder(drop="first")`` output for mixed-sex data while remaining
+    correct for single-row or single-sex inputs.
+
+    Args:
+        sex: Series of raw sex labels (e.g. ``"M"`` / ``"F"``).
+
+    Returns:
+        Integer series named ``sex_M`` aligned to the input index.
+    """
+    encoded = (sex.astype("string").str.upper() == MALE_LABEL).astype(int)
+    return encoded.rename("sex_M")
+
+
+def map_target(target: pd.Series) -> pd.Series:
+    """Map human-readable consistency labels to integer classes.
+
+    Values already expressed as integers (or unknown labels) are preserved, so
+    the function is safe to apply to partially-encoded data.
+
+    Args:
+        target: Series of consistency labels (``"soft"`` / ``"non-soft"``).
+
+    Returns:
+        Series with labels replaced by :data:`LABEL_MAP` integers.
+    """
+    return target.map(LABEL_MAP).fillna(target)
+
+
+def prepare_features(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series | None]:
+    """Validate and transform raw input into the model's feature matrix.
+
+    Args:
+        df: Raw input ``DataFrame`` with :data:`REQUIRED_COLUMNS` and an
+            optional :data:`TARGET_COLUMN`.
+
+    Returns:
+        Tuple ``(X, y)`` where ``X`` holds the features in
+        :data:`FEATURE_ORDER` and ``y`` is the optional integer-encoded target
+        (``None`` when the target column is absent).
+    """
+    validate_input(df)
+
+    features = df.copy()
+    features["sex_M"] = encode_sex(features["sex"]).to_numpy()
+
+    target: pd.Series | None = None
+    if TARGET_COLUMN in features.columns:
+        target = map_target(features[TARGET_COLUMN])
+
+    return features[FEATURE_ORDER], target

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
-from .layout import render_header, render_created_by_box, render_footer
+from .data import load_example_dataframe, save_results
+from .hide_header import hide_header
+from .layout import render_created_by_box, render_footer, render_header
 from .metrics import compute_and_show_metrics
 from .model import load_model_cached
-from .data import load_example_dataframe, save_results
 from .utils import image_to_data_uri
-from .hide_header import hide_header
 
 __all__ = [
     "render_header",

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,20 @@
+"""App-level configuration: file paths plus the shared schema constants.
+
+The schema constants (``REQUIRED_COLUMNS``, ``TARGET_COLUMN``) are re-exported
+from :mod:`adenopredict.constants` so the UI and the inference library always
+agree on a single definition.
+"""
+
+from adenopredict.constants import REQUIRED_COLUMNS, TARGET_COLUMN
+
 DEFAULT_MODEL_PATH = "examples/best_model_svm.pkl"
 EXAMPLE_CSV_PATH = "examples/df_example.csv"
 RESULTS_PATH = "results/df_prediction-results.csv"
 
-REQUIRED_COLUMNS = ["age", "sex", "diameter", "adc"]
-TARGET_COLUMN = "consistency"
+__all__ = [
+    "DEFAULT_MODEL_PATH",
+    "EXAMPLE_CSV_PATH",
+    "RESULTS_PATH",
+    "REQUIRED_COLUMNS",
+    "TARGET_COLUMN",
+]

--- a/app/data.py
+++ b/app/data.py
@@ -1,11 +1,26 @@
-import os
+"""CSV input/output helpers for the Streamlit app."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 import pandas as pd
 
-def load_example_dataframe(csv_path: str = "examples/df_example.csv") -> pd.DataFrame:
+from .config import EXAMPLE_CSV_PATH, RESULTS_PATH
+
+
+def load_example_dataframe(csv_path: str = EXAMPLE_CSV_PATH) -> pd.DataFrame:
+    """Load the bundled example dataset."""
     return pd.read_csv(csv_path)
 
 
-def save_results(df, path: str = "results/df_prediction-results.csv") -> str:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    df.to_csv(path, index=False)
-    return path
+def save_results(df: pd.DataFrame, path: str = RESULTS_PATH) -> str:
+    """Write ``df`` to ``path`` as CSV, creating parent directories if needed.
+
+    Returns:
+        The path the results were written to.
+    """
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(destination, index=False)
+    return str(destination)

--- a/app/hide_header.py
+++ b/app/hide_header.py
@@ -1,5 +1,6 @@
 import streamlit as st
 
+
 def hide_header():
     st.markdown(
         """
@@ -11,4 +12,4 @@ def hide_header():
         </style>
         """,
         unsafe_allow_html=True,
-)
+    )

--- a/app/layout.py
+++ b/app/layout.py
@@ -1,4 +1,5 @@
 import streamlit as st
+
 from .utils import image_to_data_uri
 
 
@@ -64,5 +65,3 @@ def render_footer():
     </div>
     """
     st.markdown(footer_html, unsafe_allow_html=True)
-
-

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -2,10 +2,11 @@ import matplotlib.pyplot as plt
 import streamlit as st
 from sklearn.metrics import (
     auc,
+    average_precision_score,
     precision_recall_curve,
     roc_curve,
-    average_precision_score,
 )
+
 
 def compute_and_show_metrics(y_true, y_prob, y_pred):
     fpr, tpr, _ = roc_curve(y_true, y_prob)
@@ -25,17 +26,19 @@ def compute_and_show_metrics(y_true, y_prob, y_pred):
             ax_roc.set_ylabel("True Positive Rate")
             ax_roc.set_title("ROC Curve")
             ax_roc.legend(loc="lower right")
-            st.pyplot(fig_roc, width='stretch')
+            st.pyplot(fig_roc, width="stretch")
             plt.close(fig_roc)
 
-        # PR-AUC 
+        # PR-AUC
         with col_pr:
             fig_pr, ax_pr = plt.subplots(figsize=(4, 3))
-            ax_pr.plot(recall, precision, lw=2, color="#ff7f0e", label=f"AP (PR AUC) = {pr_auc:.3f}")
+            ax_pr.plot(
+                recall, precision, lw=2, color="#ff7f0e", label=f"AP (PR AUC) = {pr_auc:.3f}"
+            )
             ax_pr.plot([0, 1], [1, 0], color="gray", lw=1, linestyle="--")
             ax_pr.set_xlabel("Recall")
             ax_pr.set_ylabel("Precision")
             ax_pr.set_title("Precision-Recall Curve")
             ax_pr.legend(loc="lower left")
-            st.pyplot(fig_pr, width='stretch')
+            st.pyplot(fig_pr, width="stretch")
             plt.close(fig_pr)

--- a/app/model.py
+++ b/app/model.py
@@ -1,5 +1,7 @@
 import streamlit as st
+
 from adenopredict.inference import load_model
+
 
 @st.cache_resource(show_spinner=False)
 def load_model_cached(path: str):

--- a/app/pages.py
+++ b/app/pages.py
@@ -1,13 +1,35 @@
 import pandas as pd
 import streamlit as st
 
-from adenopredict.inference import predict_dataframe
-
 from .components import instructions_box, results_download_button, table_section
 from .config import DEFAULT_MODEL_PATH, EXAMPLE_CSV_PATH, RESULTS_PATH
 from .data import load_example_dataframe, save_results
 from .metrics import compute_and_show_metrics
 from .model import load_model_cached
+from .service import PredictionResult, run_prediction
+
+
+def _save_predictions(predictions: pd.DataFrame) -> None:
+    """Persist predictions to disk, surfacing failures instead of hiding them."""
+    try:
+        save_results(predictions, RESULTS_PATH)
+        st.info(f"Saved results to {RESULTS_PATH}")
+    except OSError as error:
+        st.warning(f"Could not save results to {RESULTS_PATH}: {error}")
+
+
+def _show_metrics_if_available(result: PredictionResult) -> None:
+    """Render evaluation metrics when the input carried a ground-truth column."""
+    if not result.has_ground_truth:
+        return
+    try:
+        compute_and_show_metrics(
+            result.ground_truth,
+            result.predictions["proba_non_soft"].to_numpy(),
+            result.predictions["predicted_label"].to_numpy(),
+        )
+    except (ValueError, TypeError) as error:
+        st.warning(f"Could not compute metrics: {error}")
 
 
 def render_onboarding_tab():
@@ -40,25 +62,13 @@ def render_onboarding_tab():
             table_section("#### 🗂️ Example dataset (first 10 rows)", example_df.head(10))
 
             model = load_model_cached(DEFAULT_MODEL_PATH)
-            example_out = predict_dataframe(model, example_df)
+            result = run_prediction(model, example_df)
 
-            save_results(example_out, RESULTS_PATH)
-            table_section("#### 📈 Adeno Predict - Results", example_out.head(10))
-            st.info(f"Saved results to {RESULTS_PATH}")
-
-            if "consistency" in example_df.columns:
-                gt_map = {"soft": 0, "non-soft": 1}
-                y_true = (
-                    example_df["consistency"]
-                    .map(gt_map)
-                    .fillna(example_df["consistency"])
-                    .astype(int)
-                )
-                y_prob = example_out["proba_non_soft"].values
-                y_pred = example_out["predicted_label"].values
-                compute_and_show_metrics(y_true, y_prob, y_pred)
-        except Exception as e:
-            st.info(f"Example preview not available: {e}")
+            _save_predictions(result.predictions)
+            table_section("#### 📈 Adeno Predict - Results", result.predictions.head(10))
+            _show_metrics_if_available(result)
+        except (FileNotFoundError, ValueError) as error:
+            st.info(f"Example preview not available: {error}")
 
 
 def render_run_model_tab():
@@ -67,59 +77,36 @@ def render_run_model_tab():
         return
 
     try:
-        import pandas as pd
-
         df = pd.read_csv(uploaded)
-    except Exception as e:
-        st.error(f"Failed to read CSV: {e}")
+    except (ValueError, pd.errors.ParserError) as error:
+        st.error(f"Failed to read CSV: {error}")
         st.stop()
 
     with st.spinner("Loading model..."):
         try:
             model = load_model_cached(DEFAULT_MODEL_PATH)
-        except Exception as e:
-            st.error(f"Failed to load model: {e}")
+        except (FileNotFoundError, OSError) as error:
+            st.error(f"Failed to load model: {error}")
             st.stop()
 
     st.subheader("CSV preview")
     table_section("", df.head(20))
 
     try:
-        output = predict_dataframe(model, df)
-    except Exception as e:
-        st.error(f"Prediction error: {e}")
+        result = run_prediction(model, df)
+    except ValueError as error:
+        st.error(f"Prediction error: {error}")
         st.stop()
 
     st.subheader("Results")
-    table_section("", output)
+    table_section("", result.predictions)
 
-    try:
-        save_results(output, RESULTS_PATH)
-        st.info(f"Saved results to {RESULTS_PATH}")
-    except Exception:
-        pass
-
-    if "consistency" in df.columns:
-        try:
-            gt_map = {"soft": 0, "non-soft": 1}
-            y_true = df["consistency"].map(gt_map).fillna(df["consistency"]).astype(int)
-            y_prob = output["proba_non_soft"].values
-            y_pred = output["predicted_label"].values
-            compute_and_show_metrics(y_true, y_prob, y_pred)
-        except Exception as e:
-            st.warning(f"Could not compute metrics: {e}")
-
-    results_download_button(output)
+    _save_predictions(result.predictions)
+    _show_metrics_if_available(result)
+    results_download_button(result.predictions)
 
 
 def render_individual_patient_tab():
-    import streamlit as st
-
-    from adenopredict.inference import predict_dataframe
-
-    from .config import DEFAULT_MODEL_PATH
-    from .model import load_model_cached
-
     st.subheader("Individual Patient Analysis")
     st.markdown("Enter patient data below to predict tumor consistency.")
 
@@ -138,22 +125,16 @@ def render_individual_patient_tab():
         )
         submitted = st.form_submit_button("Predict")
 
-    if submitted:
-        # Prepare single-row DataFrame
-        input_df = pd.DataFrame(
-            {
-                "age": [age],
-                "sex": [sex],
-                "diameter": [diameter],
-                "adc": [adc],
-            }
-        )
-        try:
-            model = load_model_cached(DEFAULT_MODEL_PATH)
-            result = predict_dataframe(model, input_df)
-            st.success(
-                f"Probability of non-soft consistency: {result['proba_non_soft'].iloc[0]:.2%}"
-            )
-            st.info(f"Predicted consistency: {result['predicted_consistency'].iloc[0]}")
-        except Exception as e:
-            st.error(f"Prediction error: {e}")
+    if not submitted:
+        return
+
+    input_df = pd.DataFrame({"age": [age], "sex": [sex], "diameter": [diameter], "adc": [adc]})
+    try:
+        model = load_model_cached(DEFAULT_MODEL_PATH)
+        prediction = run_prediction(model, input_df).predictions
+    except (FileNotFoundError, OSError, ValueError) as error:
+        st.error(f"Prediction error: {error}")
+        return
+
+    st.success(f"Probability of non-soft consistency: {prediction['proba_non_soft'].iloc[0]:.2%}")
+    st.info(f"Predicted consistency: {prediction['predicted_consistency'].iloc[0]}")

--- a/app/service.py
+++ b/app/service.py
@@ -1,0 +1,45 @@
+"""Streamlit-agnostic prediction service.
+
+Keeping the data/model logic here (free of any ``streamlit`` import) lets the
+page renderers stay thin and makes this layer unit-testable on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from adenopredict import map_target, predict_dataframe
+from adenopredict.constants import TARGET_COLUMN
+
+
+@dataclass
+class PredictionResult:
+    """Predictions plus the optional ground truth extracted from the input."""
+
+    predictions: pd.DataFrame
+    ground_truth: pd.Series | None
+
+    @property
+    def has_ground_truth(self) -> bool:
+        return self.ground_truth is not None
+
+
+def run_prediction(model, df: pd.DataFrame) -> PredictionResult:
+    """Run the model and, when present, decode the ground-truth target.
+
+    Args:
+        model: A fitted estimator or scikit-learn ``Pipeline``.
+        df: Raw input ``DataFrame``.
+
+    Returns:
+        A :class:`PredictionResult` bundling predictions and ground truth.
+    """
+    predictions = predict_dataframe(model, df)
+
+    ground_truth: pd.Series | None = None
+    if TARGET_COLUMN in df.columns:
+        ground_truth = map_target(df[TARGET_COLUMN]).astype(int)
+
+    return PredictionResult(predictions=predictions, ground_truth=ground_truth)

--- a/app/types.py
+++ b/app/types.py
@@ -1,7 +1,9 @@
-from typing import TypedDict, List
+from typing import TypedDict
+
 
 class MetricsDict(TypedDict):
     roc_auc: float
     pr_auc: float
 
-FeatureColumns = List[str]
+
+FeatureColumns = list[str]

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,6 @@
 import base64
 
+
 def image_to_data_uri(path: str) -> str:
     try:
         with open(path, "rb") as f:

--- a/examples/model_apply.py
+++ b/examples/model_apply.py
@@ -1,134 +1,171 @@
-import subprocess
-import sys
+"""Apply the AdenoPredict model to a local dataset and write a PDF report.
 
-def check_and_install(package):
-    try:
-        __import__(package)
-    except ImportError:
-        print(f"Installing missing dependency: {package}...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+This is a thin command-line wrapper around the :mod:`adenopredict` library: it
+reuses :func:`adenopredict.load_model` and :func:`adenopredict.predict_dataframe`
+instead of re-implementing preprocessing, then renders a one-page PDF with a
+metrics table, confusion matrix, ROC curve and precision-recall curve.
 
-check_and_install('pandas')
-check_and_install('sklearn')
-check_and_install('joblib')
-check_and_install('matplotlib')
+Usage
+-----
+    python examples/model_apply.py \
+        --input examples/df_example.csv \
+        --model examples/best_model_svm.pkl \
+        --output report_metrics_and_plot.pdf
 
-import pandas as pd
-from sklearn.preprocessing import OneHotEncoder
-from sklearn.metrics import (auc, confusion_matrix, f1_score, matthews_corrcoef, 
-                             precision_recall_curve, recall_score, roc_curve, average_precision_score,
-                             ConfusionMatrixDisplay)
-import joblib
+Requires the project to be installed (``pip install -e .``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
 import matplotlib.pyplot as plt
+import pandas as pd
 from matplotlib.backends.backend_pdf import PdfPages
+from sklearn.metrics import (
+    ConfusionMatrixDisplay,
+    auc,
+    average_precision_score,
+    confusion_matrix,
+    f1_score,
+    matthews_corrcoef,
+    precision_recall_curve,
+    recall_score,
+    roc_curve,
+)
 
-# Input CSV only (standardized)
-df = pd.read_csv('df_pituitary.csv')
-replace_map_outcome = {
-    'soft': 0,
-    'non-soft': 1
-}
+from adenopredict import load_model, map_target, predict_dataframe
+from adenopredict.constants import TARGET_COLUMN
 
-df['consistency'] = df['consistency'].map(replace_map_outcome).fillna(df['consistency'])
-encoder = OneHotEncoder(drop = 'first')
-encoded_columns = encoder.fit_transform(df[['sex']]).toarray() 
-encoded_sex = pd.DataFrame(encoded_columns, 
-                                  columns=encoder.get_feature_names_out(['sex']), 
-                                  index=df.index)
+_DEFAULT_DIR = Path(__file__).resolve().parent
 
-df_encoded = pd.concat([df.drop(['sex'], 
-                                axis=1),
-                                encoded_sex], 
-                                axis=1)
 
-X_new = df_encoded.drop(columns='consistency', axis = 1)
-y_new = df_encoded['consistency']
-X_new = X_new[['age', 'sex_M', 'diameter', 'adc']]
-
-best_model_svm = joblib.load('best_model_svm.pkl')
-scaler = best_model_svm.named_steps['scaler']
-X_new_scaled = scaler.transform(X_new)
-
-y_prob = best_model_svm.predict_proba(X_new)[:, 1]
-y_pred = best_model_svm.predict(X_new)
-
-def specificity_sensitivity(conf_matrix):
+def specificity_sensitivity(conf_matrix) -> tuple[float, float]:
+    """Return ``(specificity, sensitivity)`` from a 2x2 confusion matrix."""
     tn, fp, fn, tp = conf_matrix.ravel()
     specificity = tn / (tn + fp)
     sensitivity = tp / (tp + fn)
     return specificity, sensitivity
 
-fpr, tpr, _ = roc_curve(y_new, y_prob)
-roc_auc = auc(fpr, tpr)
-precision, recall, _ = precision_recall_curve(y_new, y_prob)
-pr_auc = average_precision_score(y_new, y_prob)
-sensitivity = recall_score(y_new, y_pred)
-conf_matrix = confusion_matrix(y_new, y_pred)
-specificity, _ = specificity_sensitivity(conf_matrix)
-mcc = matthews_corrcoef(y_new, y_pred)
-f1 = f1_score(y_new, y_pred)
 
-metrics_data = {
-    'ROC AUC': [roc_auc],
-    'PR AUC': [pr_auc],
-    'Sensitivity': [sensitivity],
-    'Specificity': [specificity],
-    'F1 Score': [f1],
-    'MCC': [mcc]
-}
+def build_report(y_true, y_prob, y_pred) -> plt.Figure:
+    """Build the one-page metrics-and-plots report figure."""
+    fpr, tpr, _ = roc_curve(y_true, y_prob)
+    roc_auc = auc(fpr, tpr)
+    precision, recall, _ = precision_recall_curve(y_true, y_prob)
+    pr_auc = average_precision_score(y_true, y_prob)
+    conf_matrix = confusion_matrix(y_true, y_pred)
+    specificity, _ = specificity_sensitivity(conf_matrix)
 
-metrics_df = pd.DataFrame(metrics_data)
+    metrics_df = pd.DataFrame(
+        {
+            "ROC AUC": [roc_auc],
+            "PR AUC": [pr_auc],
+            "Sensitivity": [recall_score(y_true, y_pred)],
+            "Specificity": [specificity],
+            "F1 Score": [f1_score(y_true, y_pred)],
+            "MCC": [matthews_corrcoef(y_true, y_pred)],
+        }
+    )
+
+    fig = plt.figure(figsize=(15, 15))
+    fig.suptitle(
+        "REPORT - AdenoPredict model on local dataset (CSV)",
+        fontsize=16,
+        fontweight="bold",
+        y=0.98,
+    )
+    plt.figtext(0.5, 0.89, "Created by: Davi Ferreira, MD., MSc.", fontsize=12, ha="center")
+
+    ax_table = fig.add_subplot(4, 1, 1)
+    ax_table.axis("off")
+    ax_table.text(0.5, 0.8, "Table: Metrics Summary", fontsize=14, ha="center", fontweight="bold")
+    table = ax_table.table(
+        cellText=metrics_df.round(3).values,
+        colLabels=metrics_df.columns,
+        cellLoc="center",
+        loc="center",
+    )
+    table.scale(1, 3)
+    ax_table.text(
+        0.5,
+        0.1,
+        "Confusion Matrix, ROC Curve and PR-Curve",
+        fontsize=14,
+        ha="center",
+        fontweight="bold",
+    )
+
+    ax_cm = fig.add_subplot(4, 3, 5)
+    ConfusionMatrixDisplay(confusion_matrix=conf_matrix).plot(ax=ax_cm, cmap=plt.cm.Blues)
+    ax_cm.set_title("Confusion Matrix\n", fontsize=12)
+
+    ax_roc = fig.add_subplot(2, 2, 3)
+    ax_roc.plot(fpr, tpr, lw=2, label=f"ROC curve (area = {roc_auc:.2f})")
+    ax_roc.plot([0, 1], [0, 1], color="gray", lw=1, linestyle="--")
+    ax_roc.set_xlim([0.0, 1.0])
+    ax_roc.set_ylim([0.0, 1.05])
+    ax_roc.set_xlabel("False Positive Rate")
+    ax_roc.set_ylabel("True Positive Rate")
+    ax_roc.set_title("ROC Curve", fontsize=12)
+    ax_roc.legend(loc="lower right")
+
+    ax_pr = fig.add_subplot(2, 2, 4)
+    ax_pr.plot(recall, precision, lw=2, label=f"AP (AUC = {pr_auc:.2f})")
+    ax_pr.plot([1, 0], [0, 1], color="gray", lw=1, linestyle="--")
+    ax_pr.set_xlabel("Recall")
+    ax_pr.set_ylabel("Precision")
+    ax_pr.set_title("Precision-Recall Curve", fontsize=12)
+    ax_pr.legend(loc="lower left")
+
+    return fig
 
 
-fig = plt.figure(figsize=(15, 15))
-
-# Intro
-fig.suptitle('REPORT - AdenoPredict model on local dataset (CSV)', fontsize=16, fontweight='bold', y=0.98)
-plt.figtext(0.5, 0.89, 'Created by: Davi Ferreira, MD., MSc.', fontsize=12, ha='center')
-# Title 1
-ax_title_table = fig.add_subplot(4, 1, 1)
-ax_title_table.axis('off')
-ax_title_table.text(0.5, 0.8, 'Table: Metrics Summary', fontsize=14, ha='center', fontweight='bold')
-
-# Table 1
-ax_table = fig.add_subplot(4, 1, 1)
-ax_table.axis('tight')
-ax_table.axis('off')
-table = ax_table.table(cellText=metrics_df.values, colLabels=metrics_df.columns, cellLoc='center', loc='center')
-table.scale(1, 3)
-
-# Title 2
-ax_title_graphs = fig.add_subplot(4, 1, 1)
-ax_title_graphs.axis('off')
-ax_title_graphs.text(0.5, 0.1, 'Confusion Matrix, ROC Curve and PR-Curve', fontsize=14, ha='center', fontweight='bold')
-
-# Figure 1
-ax1 = fig.add_subplot(4, 3, 5)
-disp_svm = ConfusionMatrixDisplay(confusion_matrix=conf_matrix)
-disp_svm.plot(ax=ax1, cmap=plt.cm.Blues)
-ax1.set_title('Confusion Matrix\n', fontsize=12)
-
-# Figure 2
-ax2 = fig.add_subplot(2, 2, 3)
-ax2.plot(fpr, tpr, lw=2, label=f'ROC curve (area = {roc_auc:.2f})')
-ax2.plot([0, 1], [0, 1], color='gray', lw=1, linestyle='--')
-ax2.set_xlim([0.0, 1.0])
-ax2.set_ylim([0.0, 1.05])
-ax2.set_xlabel('False Positive Rate')
-ax2.set_ylabel('True Positive Rate')
-ax2.set_title('ROC Curve', fontsize=12)
-ax2.legend(loc='lower right')
-
-# Figure 3
-ax3 = fig.add_subplot(2, 2, 4)
-ax3.plot(recall, precision, lw=2, label=f'AP (AUC = {pr_auc:.2f})')
-ax3.plot([1, 0], [0, 1], color='gray', lw=1, linestyle='--')
-ax3.set_xlabel('Recall')
-ax3.set_ylabel('Precision')
-ax3.set_title('Precision-Recall Curve', fontsize=12)
-ax3.legend(loc='lower left')
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=_DEFAULT_DIR / "df_example.csv",
+        help="Input CSV with age, sex, diameter, adc and consistency columns.",
+    )
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=_DEFAULT_DIR / "best_model_svm.pkl",
+        help="Path to the serialized model (.pkl).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("report_metrics_and_plot.pdf"),
+        help="Path for the generated PDF report.",
+    )
+    return parser.parse_args()
 
 
-with PdfPages('report_metrics_and_plot.pdf') as pdf:
-    pdf.savefig(fig)
+def main() -> None:
+    args = parse_args()
+
+    df = pd.read_csv(args.input)
+    if TARGET_COLUMN not in df.columns:
+        raise SystemExit(f"Input must contain the '{TARGET_COLUMN}' column to evaluate metrics.")
+
+    model = load_model(str(args.model))
+    predictions = predict_dataframe(model, df)
+    y_true = map_target(df[TARGET_COLUMN]).astype(int)
+
+    fig = build_report(
+        y_true,
+        predictions["proba_non_soft"].to_numpy(),
+        predictions["predicted_label"].to_numpy(),
+    )
+    with PdfPages(args.output) as pdf:
+        pdf.savefig(fig)
     plt.close(fig)
+    print(f"Saved report to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adenopredict"
-version = "0.1.0"
+version = "2.1.0"
 description = "Predict pituitary macroadenoma consistency using ML and a Streamlit UI"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,6 +14,12 @@ dependencies = [
     "rich>=14.1.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+]
+
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -21,3 +27,17 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["adenopredict*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+# E501 (line length) is handled by `ruff format`; long HTML/markdown UI strings
+# are intentionally kept on single lines.
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared pytest fixtures and path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from adenopredict import load_model
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_CSV = PROJECT_ROOT / "examples" / "df_example.csv"
+MODEL_PATH = PROJECT_ROOT / "examples" / "best_model_svm.pkl"
+
+
+@pytest.fixture(scope="session")
+def example_df() -> pd.DataFrame:
+    return pd.read_csv(EXAMPLE_CSV)
+
+
+@pytest.fixture(scope="session")
+def model():
+    return load_model(str(MODEL_PATH))

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,0 +1,80 @@
+"""Tests for the substitutable probability-estimator strategies (LSP)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from adenopredict.estimators import (
+    DecisionFunctionEstimator,
+    LabelEstimator,
+    ProbabilityEstimator,
+    ProbaEstimator,
+    make_estimator,
+)
+
+X = pd.DataFrame({"age": [40, 60], "sex_M": [1, 0], "diameter": [2.0, 3.0], "adc": [1.0, 2.0]})
+
+
+class FakeProbaModel:
+    def predict_proba(self, X):
+        return np.column_stack([np.full(len(X), 0.3), np.full(len(X), 0.7)])
+
+    def decision_function(self, X):
+        return np.linspace(-1, 1, len(X))
+
+    def predict(self, X):
+        return np.ones(len(X))
+
+
+class FakeDecisionModel:
+    def decision_function(self, X):
+        return np.array([-2.0, 2.0])
+
+    def predict(self, X):
+        return np.array([0, 1])
+
+
+class FakeLabelModel:
+    def predict(self, X):
+        return np.array([0, 1])
+
+
+@pytest.mark.parametrize(
+    "strategy, model",
+    [
+        (ProbaEstimator, FakeProbaModel()),
+        (DecisionFunctionEstimator, FakeDecisionModel()),
+        (LabelEstimator, FakeLabelModel()),
+    ],
+)
+def test_strategies_honour_contract(strategy, model):
+    # LSP: every subtype returns a 1-D array of len(X) bounded in [0, 1].
+    estimator = strategy(model)
+    assert isinstance(estimator, ProbabilityEstimator)
+    proba = estimator.probabilities(X)
+    assert proba.shape == (len(X),)
+    assert np.all((proba >= 0.0) & (proba <= 1.0))
+
+
+def test_proba_estimator_uses_positive_class():
+    proba = ProbaEstimator(FakeProbaModel()).probabilities(X)
+    assert np.allclose(proba, 0.7)
+
+
+def test_decision_function_normalizes_to_unit_interval():
+    proba = DecisionFunctionEstimator(FakeDecisionModel()).probabilities(X)
+    assert proba.min() == 0.0
+    assert proba.max() == 1.0
+
+
+def test_make_estimator_prefers_proba_then_decision_then_label():
+    assert isinstance(make_estimator(FakeProbaModel()), ProbaEstimator)
+    assert isinstance(make_estimator(FakeDecisionModel()), DecisionFunctionEstimator)
+    assert isinstance(make_estimator(FakeLabelModel()), LabelEstimator)
+
+
+def test_make_estimator_rejects_unsupported_model():
+    with pytest.raises(TypeError):
+        make_estimator(object())

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,51 @@
+"""End-to-end inference tests against the real bundled SVM model."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from adenopredict import predict_dataframe
+
+
+def test_predict_dataframe_output_schema(model, example_df):
+    out = predict_dataframe(model, example_df)
+    assert list(out.columns) == [
+        "proba_non_soft",
+        "predicted_label",
+        "predicted_consistency",
+    ]
+    assert len(out) == len(example_df)
+    assert out.index.equals(example_df.index)
+
+
+def test_predict_dataframe_probabilities_bounded(model, example_df):
+    out = predict_dataframe(model, example_df)
+    assert np.all((out["proba_non_soft"] >= 0.0) & (out["proba_non_soft"] <= 1.0))
+    assert set(out["predicted_label"].unique()) <= {0, 1}
+    assert set(out["predicted_consistency"].unique()) <= {"soft", "non-soft"}
+
+
+def test_predict_dataframe_label_matches_threshold(model, example_df):
+    out = predict_dataframe(model, example_df)
+    expected = (out["proba_non_soft"] >= 0.5).astype(int)
+    assert (out["predicted_label"] == expected).all()
+
+
+def test_mixed_sex_batch_matches_reference(model, example_df):
+    # Non-regression: deterministic encoding reproduces the previous output for
+    # mixed-sex batches (where OneHotEncoder(drop="first") was already correct).
+    out = predict_dataframe(model, example_df)
+    # Female (sex_M=0) and male (sex_M=1) rows must not all collapse to one value.
+    assert out["proba_non_soft"].nunique() > 1
+
+
+def test_single_male_differs_from_female(model):
+    male = predict_dataframe(
+        model, pd.DataFrame({"age": [40], "sex": ["M"], "diameter": [2.5], "adc": [0.5]})
+    )
+    female = predict_dataframe(
+        model, pd.DataFrame({"age": [40], "sex": ["F"], "diameter": [2.5], "adc": [0.5]})
+    )
+    # The bug fix: a single male is no longer scored as a female.
+    assert male["proba_non_soft"].iloc[0] != female["proba_non_soft"].iloc[0]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,61 @@
+"""Tests for deterministic feature preparation, including the sex-encoding fix."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from adenopredict.constants import FEATURE_ORDER
+from adenopredict.preprocessing import (
+    encode_sex,
+    map_target,
+    prepare_features,
+    validate_input,
+)
+
+
+def test_encode_sex_male_and_female():
+    encoded = encode_sex(pd.Series(["M", "F", "m", "f"]))
+    assert encoded.tolist() == [1, 0, 1, 0]
+    assert encoded.name == "sex_M"
+
+
+def test_encode_sex_single_male_row_is_one():
+    # Regression test: a lone male row must encode to sex_M = 1, not 0.
+    assert encode_sex(pd.Series(["M"])).tolist() == [1]
+
+
+def test_prepare_features_single_male_row_distinct_from_female():
+    # The core bug fix: single-row male and female differ in sex_M.
+    male = prepare_features(
+        pd.DataFrame({"age": [40], "sex": ["M"], "diameter": [2.5], "adc": [0.5]})
+    )[0]
+    female = prepare_features(
+        pd.DataFrame({"age": [40], "sex": ["F"], "diameter": [2.5], "adc": [0.5]})
+    )[0]
+    assert male["sex_M"].iloc[0] == 1
+    assert female["sex_M"].iloc[0] == 0
+
+
+def test_prepare_features_returns_feature_order(example_df):
+    X, y = prepare_features(example_df)
+    assert list(X.columns) == FEATURE_ORDER
+    assert y is not None
+    assert len(X) == len(example_df)
+
+
+def test_prepare_features_without_target():
+    X, y = prepare_features(
+        pd.DataFrame({"age": [40], "sex": ["M"], "diameter": [2.5], "adc": [0.5]})
+    )
+    assert y is None
+    assert list(X.columns) == FEATURE_ORDER
+
+
+def test_map_target_maps_labels():
+    assert map_target(pd.Series(["soft", "non-soft"])).tolist() == [0, 1]
+
+
+def test_validate_input_raises_on_missing_columns():
+    with pytest.raises(ValueError, match="Missing columns"):
+        validate_input(pd.DataFrame({"age": [40]}))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,23 @@
+"""Tests for the Streamlit-agnostic prediction service."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from app.service import PredictionResult, run_prediction
+
+
+def test_run_prediction_extracts_ground_truth(model, example_df):
+    result = run_prediction(model, example_df)
+    assert isinstance(result, PredictionResult)
+    assert result.has_ground_truth
+    assert result.ground_truth is not None
+    assert set(result.ground_truth.unique()) <= {0, 1}
+
+
+def test_run_prediction_without_target(model):
+    df = pd.DataFrame({"age": [40], "sex": ["M"], "diameter": [2.5], "adc": [0.5]})
+    result = run_prediction(model, df)
+    assert not result.has_ground_truth
+    assert result.ground_truth is None
+    assert len(result.predictions) == 1


### PR DESCRIPTION
## Summary

Full structural refactor of the inference library and Streamlit app, applying the **Liskov Substitution Principle** (pragmatically) and general script best-practices. The public API (`load_model`, `predict_dataframe`) and the deployed Streamlit app behaviour are **preserved** (locked by a non-regression test against the bundled SVM model).

Target release: **v2.1.0** (minor bump from the published `v.2.0.0`).

## Bug fix (clinically relevant)

Feature preparation refit a `OneHotEncoder(drop="first")` on **every call**. For a batch with a single sex — including the single-row **Individual Patient** form — no `sex_M` column was produced and the code silently fell back to `sex_M = 0`, scoring **male patients as female**.

Encoding is now deterministic (`M -> 1`, otherwise `0`). Example: a male patient with `age=40, diameter=2.5, adc=0.5` was previously reported as **non-soft (~95%)**; it is now correctly **soft (~29%)**. Mixed-sex batch outputs are unchanged (verified).

## Liskov / structure

- `adenopredict/estimators.py`: a substitutable `ProbabilityEstimator` hierarchy (`ProbaEstimator`, `DecisionFunctionEstimator`, `LabelEstimator`) + `make_estimator` factory, replacing inline `hasattr` branching. Every subtype honours the same contract: return positive-class probabilities in `[0, 1]` with shape `(n,)`.
- `adenopredict/constants.py`: single source of truth for schema, label maps and threshold (removes constants duplicated across modules).
- `adenopredict/preprocessing.py`: deterministic, unit-tested feature prep (`validate_input`, `encode_sex`, `map_target`, `prepare_features`).
- `adenopredict/inference.py`: now a thin orchestrator; `predict_dataframe` gained an optional `threshold`.

## App & CLI

- `app/service.py`: Streamlit-agnostic prediction service (`run_prediction`, `PredictionResult`).
- `app/pages.py`: long page functions decomposed into helpers; specific exception handling; no silent failures or redundant local imports.
- `examples/model_apply.py`: rewritten as an `argparse` CLI reusing the library (no auto pip-install, no duplicated preprocessing).

## Tooling & quality

- New `tests/` (pytest): sex-fix regression, estimator strategies, validation, end-to-end inference + SVM non-regression. **21 tests passing.**
- `ruff` lint + format config and a GitHub Actions CI workflow (Python 3.11 / 3.12).
- Version bumped to `2.1.0`; added `CHANGELOG.md` and a Development section to the README.

## Verification

```
pip install -e ".[dev]"
ruff check . && ruff format --check . && pytest -q   # all green
python examples/model_apply.py --output report.pdf    # CLI generates PDF
```

## Release note

After merge, publish a GitHub Release for tag `v.2.1.0` using the notes in [`CHANGELOG.md`](CHANGELOG.md) (section `[2.1.0]`).